### PR TITLE
Update to react-router

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^7.6.2"
+    "react-router": "^7.6.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.24",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   createBrowserRouter,
   RouterProvider,
-} from 'react-router-dom';
+} from 'react-router';
 import Home from './pages/Home';
 import Results from './pages/Results';
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { startResearch } from '../lib/api';
 import LoadingSpinner from '../components/LoadingSpinner';
 

--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import { fetchResult } from '../lib/api';
 import useResearchStream from '../hooks/useResearchStream';
 


### PR DESCRIPTION
## Summary
- use `react-router` instead of deprecated `react-router-dom`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68466fcf7a6c832cb87d40184b1f7fd3