### PR TITLE
Align frontend with backend API response

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,15 +1,20 @@
-export async function startResearch(topic: string) {
+export interface ResearchResponse {
+  id: string;
+  result: string | null;
+}
+
+export async function startResearch(topic: string): Promise<ResearchResponse> {
   const resp = await fetch('/api/research', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ topic }),
   });
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-  return resp.json() as Promise<{ id: string }>;
+  return resp.json() as Promise<ResearchResponse>;
 }
 
-export async function fetchResult(id: string) {
+export async function fetchResult(id: string): Promise<ResearchResponse> {
   const resp = await fetch(`/api/research/${id}`);
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-  return resp.json() as Promise<{ id: string; result: string | null }>;
+  return resp.json() as Promise<ResearchResponse>;
 }


### PR DESCRIPTION
## Summary
- define a `ResearchResponse` interface
- update `startResearch` and `fetchResult` to return this type

## Testing
- `npm test --silent` *(fails: No tests specified)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*
