### PR TITLE
Improve FastAPI features

### DIFF
--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 
-router = APIRouter()
+router = APIRouter(prefix="/api", tags=["health"])
 
-@router.get("/api/health")
+@router.get("/health")
 async def health() -> dict[str, str]:
     return {"status": "ok"}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,15 @@
 from fastapi import FastAPI
-from .api import router as api_router
+from contextlib import asynccontextmanager
 
-app = FastAPI()
+from .api import router as api_router
+from .services import research_runner
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    yield
+    await research_runner.shutdown()
+
+
+app = FastAPI(lifespan=lifespan)
 app.include_router(api_router)


### PR DESCRIPTION
## Summary
- group routers under `/api` prefix and add tags
- handle WebSocket disconnects
- clean up research tasks via FastAPI lifespan event
- store asyncio tasks and gracefully cancel on shutdown

## Testing
- `pytest -q`
