### PR TITLE
Update frontend websocket URL

### DIFF
--- a/frontend/src/hooks/useResearchStream.ts
+++ b/frontend/src/hooks/useResearchStream.ts
@@ -12,8 +12,10 @@ export default function useResearchStream(taskId: string) {
 
   useEffect(() => {
     if (!taskId) return;
-    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-    const ws = new WebSocket(`${protocol}://${window.location.host}/ws/research/${taskId}`);
+    const apiBase = import.meta.env.RESEARCH_API_URL || window.location.origin;
+    const url = new URL(`/api/ws/research/${taskId}`, apiBase);
+    url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+    const ws = new WebSocket(url.toString());
     ws.onmessage = (event) => {
       const payload: StreamMessage = JSON.parse(event.data);
       switch (payload.type) {


### PR DESCRIPTION
## Summary
- load RESEARCH_API_URL for WebSocket connections
- construct URL for `/api/ws/research/<id>` and set protocol

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475b78f6e8832ca863eedf22cd7d83