### PR TITLE
Fix CORS by allowing localhost

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 
 from .api import router as api_router
@@ -12,4 +13,12 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+# Allow CORS requests only from localhost, regardless of scheme or port.
+# Using a regex lets us match http://localhost, https://127.0.0.1, etc.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.include_router(api_router)


### PR DESCRIPTION
## Summary
- enable CORS only for localhost using regex

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68475d8d5cfc832ca444788eefb69cca